### PR TITLE
chore: group dependabot updates per ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,15 @@ updates:
     directory: "/api_go" # Location of package manifests
     schedule:
       interval: "weekly"
+    groups:
+      gomod:
+        patterns:
+          - "*"
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/ui" # Location of package manifests
     schedule:
       interval: "weekly"
+    groups:
+      npm:
+        patterns:
+          - "*"


### PR DESCRIPTION
Collapses npm (`/ui`) and gomod (`/api_go`) version updates into one grouped PR each, so Dependabot stops failing with *"cannot open any more pull requests"*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)